### PR TITLE
Update StyleCI preset to Laravel

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,1 +1,1 @@
-preset: psr2
+preset: laravel

--- a/prefill.php
+++ b/prefill.php
@@ -1,4 +1,5 @@
 <?php
+
 define('COL_DESCRIPTION', 0);
 define('COL_HELP', 1);
 define('COL_DEFAULT', 2);
@@ -14,7 +15,7 @@ $values = [];
 
 $replacements = [
     'pxgamer\\\\:package_name\\\\' => function () use (&$values) {
-        return str_replace('\\', '\\\\', $values['psr4_namespace']) . '\\\\';
+        return str_replace('\\', '\\\\', $values['psr4_namespace']).'\\\\';
     },
     ':package_name'                => function () use (&$values) {
         return $values['package_name'];
@@ -34,25 +35,27 @@ function read_from_console($prompt)
 {
     if (function_exists('readline')) {
         $line = trim(readline($prompt));
-        if (!empty($line)) {
+        if (! empty($line)) {
             readline_add_history($line);
         }
     } else {
         echo $prompt;
         $line = trim(fgets(STDIN));
     }
+
     return $line;
 }
 
 function interpolate($text, $values)
 {
-    if (!preg_match_all('/\{(\w+)\}/', $text, $m)) {
+    if (! preg_match_all('/\{(\w+)\}/', $text, $m)) {
         return $text;
     }
     foreach ($m[0] as $k => $str) {
         $f = $m[1][$k];
         $text = str_replace($str, $values[$f], $text);
     }
+
     return $text;
 }
 
@@ -72,8 +75,8 @@ do {
         $prompt = sprintf(
             '%s%s%s: ',
             $field[COL_DESCRIPTION],
-            $field[COL_HELP] ? ' (' . $field[COL_HELP] . ')' : '',
-            $field[COL_DEFAULT] !== '' ? ' [' . $default . ']' : ''
+            $field[COL_HELP] ? ' ('.$field[COL_HELP].')' : '',
+            $field[COL_DEFAULT] !== '' ? ' ['.$default.']' : ''
         );
         $values[$f] = read_from_console($prompt);
         if (empty($values[$f])) {
@@ -86,18 +89,18 @@ do {
     echo "Please, check that everything is correct:\n";
     echo "----------------------------------------------------------------------\n";
     foreach ($fields as $f => $field) {
-        echo $field[COL_DESCRIPTION] . ": $values[$f]\n";
+        echo $field[COL_DESCRIPTION].": $values[$f]\n";
     }
     echo "\n";
 } while (($modify = strtolower(read_from_console('Modify files with these values? [y/N/q] '))) != 'y');
 echo "\n";
 
 $files = array_merge(
-    glob(__DIR__ . '/*.md'),
-    glob(__DIR__ . '/*.xml.dist'),
-    glob(__DIR__ . '/composer.json'),
-    glob(__DIR__ . '/src/*.php'),
-    glob(__DIR__ . '/tests/*.php')
+    glob(__DIR__.'/*.md'),
+    glob(__DIR__.'/*.xml.dist'),
+    glob(__DIR__.'/composer.json'),
+    glob(__DIR__.'/src/*.php'),
+    glob(__DIR__.'/tests/*.php')
 );
 foreach ($files as $f) {
     $contents = file_get_contents($f);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This updates the Style CI configuration to use the Laravel preset.

See: https://docs.styleci.io/presets#laravel

The Laravel standards add significantly more style checks compared to the base PSR-2 (`psr2`) preset.

I am still undecided on whether to adopt these standards.

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
