### PR TITLE
Remove PHP Nightly from the matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,6 @@ language: php
 php:
 - '7.2'
 - '7.3'
-- 'nightly'
-
-matrix:
-    allow_failures:
-    - php: nightly
 
 ## Cache composer
 cache:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

On pretty much all my packages I include `nightly` as a build, and these fail as most package dependencies require a specific PHP version which breaks the nightly builds.

[Example of `arionum-php`](https://travis-ci.com/pxgamer/arionum-php/jobs/202207752)

## Types of changes

Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
